### PR TITLE
Fix crash when ExpandableLabel.text is set to empty string

### DIFF
--- a/Classes/ExpandableLabel.swift
+++ b/Classes/ExpandableLabel.swift
@@ -335,6 +335,7 @@ extension ExpandableLabel {
 
 private extension NSAttributedString {
     func hasFontAttribute() -> Bool {
+        guard !self.string.isEmpty else { return false }
         let font = self.attribute(NSFontAttributeName, at: 0, effectiveRange: nil) as? UIFont
         return font != nil
     }


### PR DESCRIPTION
passing into `ExpandableLabel.text` an empty string `""` will cause a crash.