### PR TITLE
Make ExpandableLabel with with attributed string

### DIFF
--- a/Classes/ExpandableLabel.swift
+++ b/Classes/ExpandableLabel.swift
@@ -142,8 +142,11 @@ open class ExpandableLabel: UILabel {
         set(attributedText) {
             if let attributedText = attributedText, attributedText.length > 0 {
                 self.collapsedText = getCollapsedText(for: attributedText, link: (linkHighlighted) ? collapsedAttributedLink.copyWithHighlightedColor() : collapsedAttributedLink)
+                self.expandedText = attributedText
                 super.attributedText = (self.collapsed) ? self.collapsedText : self.expandedText
             } else {
+                self.expandedText = nil
+                self.collapsedText = nil
                 super.attributedText = nil
             }
         }


### PR DESCRIPTION
ExpandableLabel doesn't work if you set `attributedText` on it. This PR fixes that.

This is what it looks like if you try setting `attributedText` on `ExpandableLabel`

![simulator screen shot jul 16 2017 19 42 30](https://user-images.githubusercontent.com/1733610/28250403-28240f6a-6a5f-11e7-9ffd-99d5cc2d87a8.png)
