### PR TITLE
Subclassing not possible because of `internal` constructors

### DIFF
--- a/Classes/ExpandableLabel.swift
+++ b/Classes/ExpandableLabel.swift
@@ -124,12 +124,12 @@ open class ExpandableLabel: UILabel {
         commonInit()
     }
     
-    override init(frame: CGRect) {
+    public override init(frame: CGRect) {
         super.init(frame: frame)
         self.commonInit()
     }
     
-    init() {
+    public init() {
         super.init(frame: .zero)
     }
     


### PR DESCRIPTION
Some of the constructors of `ExpandableLabel` have an `internal` access level making it impossible to create a subclass.

IB will crash if you do not implement `init(frame: CGRect)` in a `ExpandableLabel` subclass.

All constructors should be `public` so they can be overwritten.