### PR TITLE
Proper initialization of the collapsed number of lines property.

### DIFF
--- a/Classes/ExpandableLabel.swift
+++ b/Classes/ExpandableLabel.swift
@@ -136,7 +136,7 @@ open class ExpandableLabel: UILabel {
     fileprivate func commonInit() {
         self.isUserInteractionEnabled = true
         self.lineBreakMode = .byClipping
-        self.numberOfLines = 3
+        self.collapsedNumberOfLines = numberOfLines
         self.expandedAttributedLink = nil
         self.collapsedAttributedLink = NSAttributedString(string: "More", attributes: [.font: UIFont.boldSystemFont(ofSize: font.pointSize)])
         self.ellipsis = NSAttributedString(string: "...")


### PR DESCRIPTION
`commonInit` is currently called in the constructor used for decoding. I.e. it is called after the view was deserialized from a storyboard file.

Setting the `numberOfLines` property in this phase will overwrite any deserialized value which means any `numberOfLines` value set in a storyboard won't have any effect because of this.
Default values of overridden properties should never be set this way (in this case in the `commonInit` method).