### PR TITLE
Allow reading expandedText attribute

### DIFF
--- a/Classes/ExpandableLabel.swift
+++ b/Classes/ExpandableLabel.swift
@@ -102,8 +102,7 @@ open class ExpandableLabel: UILabel {
     //
     // MARK: Private
     //
-    
-    fileprivate var expandedText: NSAttributedString?
+
     fileprivate var collapsedText: NSAttributedString?
     fileprivate var linkHighlighted: Bool = false
     fileprivate let touchSize = CGSize(width: 44, height: 44)
@@ -154,6 +153,8 @@ open class ExpandableLabel: UILabel {
             return self.attributedText?.string
         }
     }
+
+    open private(set) var expandedText: NSAttributedString?
     
     open override var attributedText: NSAttributedString? {
         set(attributedText) {


### PR DESCRIPTION
Just recently found this library, and it does _precisely_ what we need in one of our projects at work. Good stuff!

However, we need to be able to measure the height of the expanded text, so it would be useful to us if the `expandedText` attribute was open for reading. I've changed the implementation to allow that, and thought this might be useful for someone else 🙂 

Any feedback on this is greatly appreciated! Thank you in advance 👍 