### PR TITLE
Set Natural paragraph style to correctly align for RTL

### DIFF
--- a/Classes/ExpandableLabel.swift
+++ b/Classes/ExpandableLabel.swift
@@ -398,7 +398,7 @@ private extension NSAttributedString {
     func copyWithParagraphAttribute(_ font: UIFont) -> NSAttributedString {
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineHeightMultiple = 1.05
-        paragraphStyle.alignment = .left
+        paragraphStyle.alignment = .natural
         paragraphStyle.lineSpacing = 0.0
         paragraphStyle.minimumLineHeight = font.lineHeight
         paragraphStyle.maximumLineHeight = font.lineHeight


### PR DESCRIPTION
Set Natural paragraph style in order to correctly align text on Right-to-Left languages